### PR TITLE
setup.py will install dependencies.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 graft scripts
-prune scripts/build
 graft blackbird
 prune blackbird/conf
 prune blackbird/tests

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 try:
     from setuptools import setup
 except ImportError:
-    from distutils import setup
+    from distutils.core import setup
 
 setup(
     name='blackbird',
@@ -20,5 +20,16 @@ setup(
     ],
     entry_points={
         'console_scripts': ['blackbird = blackbird.sr71:main']
-    }
+    },
+    install_requires=[
+        "argparse",
+        "configobj",
+        "ipaddr",
+        "lockfile",
+        "logilab-astng",
+        "logilab-common",
+        "nose",
+        "python-daemon",
+        "unittest2",
+    ],
 )


### PR DESCRIPTION
`setup.py install` or `setup.py develop` will now installs
dependencies so that you don't have to do
`pip install -r requirements.txt`.
