### PR TITLE
Get rid of "ipaddr" module from requires

### DIFF
--- a/blackbird/__init__.py
+++ b/blackbird/__init__.py
@@ -1,2 +1,2 @@
 __import__('pkg_resources').declare_namespace(__name__)
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/blackbird/plugins/base.py
+++ b/blackbird/plugins/base.py
@@ -171,7 +171,7 @@ class BlackbirdPluginError(Exception):
 class ValidatorBase(object):
     """
     e.g: check the validity of the values as follows:
-    host -> '127.0.0.1'(IPAddress),
+    host -> '127.0.0.1'(str),
     port -> '11211'(number of 0 - 65535)
     """
 
@@ -184,7 +184,7 @@ class ValidatorBase(object):
         "spec" property must be listed configobj's specfiles rules.
         e.g:
         [redis]
-        host = ipaddress(default='127.0.0.1')
+        host = string(default='127.0.0.1')
         port = port(0, 65535, default=6379)
 
         "configspec" as ConfigObj's argument must be

--- a/blackbird/utils/configread.py
+++ b/blackbird/utils/configread.py
@@ -7,7 +7,6 @@ import configobj
 import errno
 import glob
 import grp
-import ipaddr
 import os
 import pkgutil
 import pwd
@@ -369,7 +368,7 @@ class ConfigReader(base.Subject):
         raw_specs = {
             'redis': (
                 "[redis]",
-                "host = ipaddress(default='127.0.0.1')",
+                "host = string(default='127.0.0.1')",
                 "port = integer(0, 65535, default=6379)",
                 "db = integer(default=0)",
                 "charset = string(default='utf-8')",
@@ -445,7 +444,7 @@ class ConfigReader(base.Subject):
         type definitions and default values in "spec file" as follow:
         [memcached]
         module = string('memcached')
-        host = ipaddr(default='127.0.0.1')
+        host = string(default='127.0.0.1')
         port = integer(0, 65535, default=11211)
 
         Notes: Must be the same all The following values.
@@ -461,7 +460,7 @@ class ConfigReader(base.Subject):
         Returned configspec is as follows:
         [local_memcached]
         module = string('memcached')
-        host = ipaddr(default='127.0.0.1')
+        host = string(default='127.0.0.1')
         port = integer(0, 65535, default=11211)
 
         In short Rename section name in spec file
@@ -484,9 +483,6 @@ class ConfigReader(base.Subject):
         """
 
         spec = self._create_specs()
-        functions = {
-            'ipaddress': is_ipaddress,
-        }
         validator = validate.Validator(functions=functions)
 
         self.config.configspec = spec
@@ -560,25 +556,6 @@ class NotSupportedError(ValueError):
                        )
 
         super(NotSupportedError, self).__init__(err_message)
-
-
-def is_ipaddress(value):
-    u"""
-    Check whether correct IPAdress.
-    This function is defferent with built-in "ip_addr"-type.
-    Built-in "ip_addr"-type only supports IPv4.
-    But, "ipaddr" (google products) supports both IPv4 and IPv6.
-    This function's name is not like "return_ipaddress", but "is_ipaddress"
-    because it's called by ConfigReader._validate().
-    Names of functions by used in _validate() must be "is_TYPE".
-    """
-
-    try:
-        ipaddress = ipaddr.IPAddress(value)
-    except ValueError:
-        raise validate.VdtValueError(value)
-
-    return ipaddress.exploded
 
 
 def is_dir(value):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 argparse==1.2.1
 configobj==4.7.2
-ipaddr==2.1.10
 lockfile==0.9.1
 logilab-astng==0.24.1
 logilab-common==0.59.0

--- a/scripts/blackbird.spec
+++ b/scripts/blackbird.spec
@@ -3,9 +3,9 @@
 %define debug_package %{nil}
 
 %define name blackbird
-%define version 0.4.1
+%define version 0.4.2
 %define unmangled_version %{version}
-%define release 2%{dist}
+%define release 1%{dist}
 %define blackbird_user bbd
 %define blackbird_uid 187
 %define blackbird_group bbd
@@ -38,7 +38,6 @@ Provides: %{name}
 Requires: python-argparse
 Requires: python-configobj
 Requires: python-daemon
-Requires: python-ipaddr
 Requires: python-lockfile
 Requires: python-setuptools
 Requires(pre):     shadow-utils
@@ -148,6 +147,9 @@ service %{name} restart > /dev/null 2>&1 || :
 %config(noreplace) %{_sysconfdir}/logrotate.d/blackbird
 
 %changelog
+* Mon Dec 8 2014 ARASHI, Jumpei <jumpei.arashi@arashike.com> - 0.4.2-1
+- Get rid of python-ipaddr from "Requires"
+
 * Tue Sep 7 2014 makocchi <makocchi@gmail.com> - 0.4.1-2
 - support systemd
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     install_requires=[
         "argparse",
         "configobj",
-        "ipaddr",
         "lockfile",
         "logilab-astng",
         "logilab-common",


### PR DESCRIPTION
Because of
- ipaddr is used to validate whether given value is IP Address
- `hostname` parameter in config may be hostanme or IP Address
- "python-ipaddr" RPM doesn't exist in AWS RPM repository
