### PR TITLE
Logging blackbird version and plugin name

### DIFF
--- a/blackbird/sr71.py
+++ b/blackbird/sr71.py
@@ -9,6 +9,7 @@ import threading
 import time
 from daemon import DaemonContext
 
+from blackbird import __version__
 from blackbird.utils import argumentparse
 from blackbird.utils import configread
 from blackbird.utils import logger
@@ -138,7 +139,10 @@ class BlackBird(object):
                          self.config['global']['group']
                          )
 
-            self.logger.info('started main process')
+            self.logger.info(
+                'blackbird {0} : started main process'.format(__version__)
+            )
+
             pid_file = pidlockfile.PIDLockFile(self.args.pid_file)
             with DaemonContext(
                 files_preserve=[
@@ -154,7 +158,10 @@ class BlackBird(object):
                 main_loop()
 
         else:
-            self.logger.info('started main process')
+            self.logger.info(
+                'blackbird {0} : started main process in debug mode'
+                ''.format(__version__)
+            )
             main_loop()
 
 
@@ -256,6 +263,11 @@ class JobCreator(object):
                     'interval': interval,
                 }
 
+                self.logger.info(
+                    'load plugin {0} (interval {1})'
+                    ''.format(plugin_name, interval)
+                )
+
             if hasattr(job_obj, 'build_discovery_items'):
                 name = '-'.join([section, 'build_discovery_items'])
                 lld_interval = 600
@@ -268,6 +280,11 @@ class JobCreator(object):
                     'method': job_obj.build_discovery_items,
                     'interval': lld_interval,
                 }
+
+                self.logger.info(
+                    'load plugin {0} (lld_interval {1})'
+                    ''.format(plugin_name, lld_interval)
+                )
 
         return jobs
 

--- a/blackbird/utils/configread.py
+++ b/blackbird/utils/configread.py
@@ -265,7 +265,7 @@ class ConfigReader(base.Subject):
             "user = user(default=bbd)",
             "group = group(default=bbd)",
             "log_file = log(default=/var/log/blackbird/blackbird.log)",
-            "log_level = log_level(default='warn')",
+            "log_level = log_level(default='info')",
             "max_queue_length = integer(default=32767)",
             "lld_interval = integer(default=600)",
             "interval = integer(default=60)"

--- a/scripts/blackbird.cfg
+++ b/scripts/blackbird.cfg
@@ -3,4 +3,4 @@ user = bbd
 group = bbd
 include  = conf.d/*.cfg
 log_file = /var/log/blackbird/blackbird.log
-log_level = error
+log_level = info


### PR DESCRIPTION
like this

```
log_level:INFO	time:16/Jan/2015:13:32:54 +0000	process:blackbird	thread:MainThread	message:load plugin zabbix_sender (interval 60)
log_level:INFO	time:16/Jan/2015:13:32:54 +0000	process:blackbird	thread:MainThread	message:load plugin statistics (interval 60)
log_level:INFO	time:16/Jan/2015:13:32:54 +0000	process:blackbird	thread:MainThread	message:load plugin hogehoge (interval 10)
log_level:INFO	time:16/Jan/2015:13:32:54 +0000	process:blackbird	thread:MainThread	message:load plugin hogehoge (lld_interval 10)
log_level:INFO	time:16/Jan/2015:13:32:54 +0000	process:blackbird	thread:MainThread	message:blackbird 0.4.4 : started main process
```

and change default log_level to `info` from `error`