### PR TITLE
Remove '/opt/blackbird/plugins' in default `module_dir` parameter.

### DIFF
--- a/blackbird/test/configread_test/global_section_test.py
+++ b/blackbird/test/configread_test/global_section_test.py
@@ -32,8 +32,7 @@ class TestSetModuleDir(ConfigReaderBase):
         config = ConfigReader(infile=cfg_lines).config
         check_value = os.path.abspath('plugins')
 
-        print os.path.abspath(os.path.curdir)
-
+        os.path.abspath(os.path.curdir)
         ok_(check_value in config['global']['module_dir'],
             msg=('Doesn\'t insert default "module_dir" value.'
                  'All config value: {0}'.format(config)

--- a/blackbird/test/test_configread/test_global/test_module_dir.py
+++ b/blackbird/test/test_configread/test_global/test_module_dir.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import nose.tools
+
+import blackbird.utils.configread
+
+
+class TestConfigReaderAddDefaultModuleDir(object):
+
+    def test_no_module_dir(self):
+        infile = (
+            '[global]',
+            ''
+        )
+        test_config = blackbird.utils.configread.ConfigReader(
+            infile=infile
+        )
+        default_module_dir = os.path.join(
+            os.path.abspath(os.path.curdir),
+            'plugins'
+        )
+        module_dirs = test_config.config['global']['module_dir']
+        nose.tools.ok_(
+            (
+                len(module_dirs) == 1
+            ) and
+            (
+                module_dirs[0] == default_module_dir
+            )
+        )
+
+    def test_custom_module_dir(self):
+        optional_module_dir = '/opt/blackbird/plugins'
+        infile = (
+            '[global]',
+            'module_dir = {0}'.format(optional_module_dir)
+        )
+        test_config = blackbird.utils.configread.ConfigReader(
+            infile=infile
+        )
+        module_dirs = test_config.config['global']['module_dir']
+        print module_dirs
+        nose.tools.ok_(
+            (
+                len(module_dirs) == 2
+            ) and
+            (
+                module_dirs[1] == optional_module_dir
+            )
+        )

--- a/blackbird/test/test_configread/test_global/test_module_dir.py
+++ b/blackbird/test/test_configread/test_global/test_module_dir.py
@@ -41,7 +41,6 @@ class TestConfigReaderAddDefaultModuleDir(object):
             infile=infile
         )
         module_dirs = test_config.config['global']['module_dir']
-        print module_dirs
         nose.tools.ok_(
             (
                 len(module_dirs) == 2

--- a/blackbird/utils/configread.py
+++ b/blackbird/utils/configread.py
@@ -57,8 +57,7 @@ class ConfigReader(base.Subject):
 
         # validate config file
         self._merge_includes()
-        # TODO: remove this
-        self.config['global'].update(self.get_default_module_dir())
+        self.add_default_module_dir()
 
         # notify observers
         self._observers = []
@@ -225,26 +224,28 @@ class ConfigReader(base.Subject):
         for observer in self._observers:
             observer.update(name, job)
 
-    def get_default_module_dir(self):
+    def add_default_module_dir(self):
         """
-        Default "module_dir" is "./plugins" and "/opt/blackbird/plugins".
-        "./plugins" is relative path from ./sr71.py.
-        "module_dir" is used in _get_modules().
-        Plugins under the "module_dir" is written about each job.
+        Add directory to store built-in plugins to `module_dir` parameter.
+        Default directory to store plugins is `BLACKBIRD_INSTALL_DIR/plugins`.
+        :rtype: None
+        :return: None
         """
-
-        default_module_dir1 = os.path.join(
+        default_module_dir = os.path.join(
             os.path.abspath(os.path.curdir),
             'plugins'
         )
-        default_module_dir2 = '/opt/blackbird/plugins'
+        module_dir_params = {
+            'module_dir': [default_module_dir]
+        }
 
         if 'module_dir' in self.config['global']:
-            default_module_dir2 = self.config['global']['module_dir']
-
-        module_dirs = [default_module_dir1, default_module_dir2]
-        option = {'module_dir': module_dirs}
-        return option
+            module_dir_params['module_dir'].append(
+                self.config['global']['module_dir']
+            )
+        self.config['global'].update(
+            module_dir_params
+        )
 
     def global_validate(self):
         """

--- a/scripts/blackbird.cfg
+++ b/scripts/blackbird.cfg
@@ -29,3 +29,8 @@ log_level = info
 #  - combined
 #
 log_format = ltsv
+
+# ## module_dir
+# We call plugin `module`. This parameter isn't for `module configuration file`.
+# Optional directory to you install any plugins.
+module_dir = /opt/blackbird/plugins


### PR DESCRIPTION
@makocchi-git
I think hard-coded directory name (like `/opt/blackbird/plugins`) should be injected from outside of source code. by configuration file.

@Vagrants/owners  What about hard-coding `module_dir` parameter?